### PR TITLE
모든 JPA 엔티티 클래스에 `@Builder` 추가

### DIFF
--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/model/entity/Character.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/model/entity/Character.java
@@ -2,6 +2,7 @@ package com.github.hojoungjang.tekken_combo_maker.character.model.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,9 +26,8 @@ public class Character {
     @Column(name = "avatar_image")
     private String avatarImageUrl;
 
-    // TODO: find a way to remove id; updating id is dangerous
-    public Character(Long id, String name, String description, String avatarImageUrl) {
-        this.id = id;
+    @Builder
+    public Character(String name, String description, String avatarImageUrl) {
         this.name = name;
         this.description = description;
         this.avatarImageUrl = avatarImageUrl;

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/combo/model/entity/Combo.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/combo/model/entity/Combo.java
@@ -3,7 +3,10 @@ package com.github.hojoungjang.tekken_combo_maker.combo.model.entity;
 import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
 import com.github.hojoungjang.tekken_combo_maker.post.model.entity.Post;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 콤보 엔티티 클래스
@@ -11,6 +14,7 @@ import lombok.Getter;
  */
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Combo {
 
     @Id
@@ -27,5 +31,14 @@ public class Combo {
 
     private String name;
     private int damage;
-    private int hit_count;
+    private int hitCount;
+
+    @Builder
+    public Combo(Character character, Post post, String name, int damage, int hitCount) {
+        this.character = character;
+        this.post = post;
+        this.name = name;
+        this.damage = damage;
+        this.hitCount = hitCount;
+    }
 }

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/combo/model/entity/ComboMove.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/combo/model/entity/ComboMove.java
@@ -1,13 +1,17 @@
 package com.github.hojoungjang.tekken_combo_maker.combo.model.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Combo 와 Move 의 Many-to-Many 관계를 연결하는 중간 테이블용 엔티티
  */
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ComboMove {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -19,4 +23,10 @@ public class ComboMove {
 
     @Column(nullable = false)
     private String moveId;      // MongoDB 도큐먼트 ID
+
+    @Builder
+    public ComboMove(Combo combo, String moveId) {
+        this.combo = combo;
+        this.moveId = moveId;
+    }
 }

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/member/model/entity/Member.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/member/model/entity/Member.java
@@ -1,13 +1,17 @@
 package com.github.hojoungjang.tekken_combo_maker.member.model.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 사용자 엔티티 클래스
  */
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
     @Id
@@ -21,4 +25,11 @@ public class Member {
 
     @Column(unique = true)
     private String nickName;
+
+    @Builder
+    public Member(String email, String password, String nickName) {
+        this.email = email;
+        this.password = password;
+        this.nickName = nickName;
+    }
 }

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/move/model/entity/Stance.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/move/model/entity/Stance.java
@@ -2,13 +2,17 @@ package com.github.hojoungjang.tekken_combo_maker.move.model.entity;
 
 import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 캐릭터별 자세 엔티티 클래스
  */
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stance {
 
     @Id
@@ -20,4 +24,10 @@ public class Stance {
     private Character character;
 
     private String name;
+
+    @Builder
+    public Stance(Character character, String name) {
+        this.character = character;
+        this.name = name;
+    }
 }

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/post/model/entity/Comment.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/post/model/entity/Comment.java
@@ -2,13 +2,17 @@ package com.github.hojoungjang.tekken_combo_maker.post.model.entity;
 
 import com.github.hojoungjang.tekken_combo_maker.member.model.entity.Member;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 게시물 댓글 엔티티 클래스
  */
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment {
 
     @Id
@@ -30,4 +34,12 @@ public class Comment {
 
     @Column(nullable = false)
     private String content;
+
+    @Builder
+    public Comment(Member member, Post post, Comment thread, String content) {
+        this.member = member;
+        this.post = post;
+        this.thread = thread;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/post/model/entity/Post.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/post/model/entity/Post.java
@@ -2,13 +2,17 @@ package com.github.hojoungjang.tekken_combo_maker.post.model.entity;
 
 import com.github.hojoungjang.tekken_combo_maker.member.model.entity.Member;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 게시물 엔티티 클래스
  */
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 
     @Id
@@ -21,4 +25,9 @@ public class Post {
 
     // private long likes;
     // private long dislikes;
+
+    @Builder
+    public Post(Member member) {
+        this.member = member;
+    }
 }

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/mock/FakeCharacterRepository.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/mock/FakeCharacterRepository.java
@@ -5,6 +5,7 @@ import com.github.hojoungjang.tekken_combo_maker.character.service.ICharacterRep
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +20,12 @@ public class FakeCharacterRepository implements ICharacterRepository {
             String name = "character " + i;
             String description = "description " + i;
             String avatarImageUrl = "image url " + i;
-            Character character = new Character(i, name, description, avatarImageUrl);
+            Character character = Character.builder()
+                    .name(name)
+                    .description(description)
+                    .avatarImageUrl(avatarImageUrl)
+                    .build();
+            ReflectionTestUtils.setField(character, "id", i);
             characters.add(character);
         }
     }


### PR DESCRIPTION
## Summary
엔티티를 생성하고 테스트하기 위해 기본적으로 모든 엔티티 클래스에 빌더 (`@Builder`) 추가
* `@NoArgsConstructor` protected 범위로 추가해주기
* `id` 필드는 빌더에서 제외; 필요시 테스트에서만 `ReflectionTestUtils.setField()` 통해서 값 넣어주기
* 도큐먼트 클래스는 아직 확실하지 않아서 `Move` 는 변경대상에서 제외