### PR TITLE
QueryDSL 도입하여 캐릭터 검색 API 확장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,13 @@ dependencies {
 
 	// env 파일 로드해 key-value 객체로 사용
 	implementation 'io.github.cdimascio:dotenv-java:3.2.0'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	testAnnotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	testAnnotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperty "spring.profiles.active", "test"
 }
 
 tasks.register('seedMoveData', JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Swagger 문서
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
 	// env 파일 로드해 key-value 객체로 사용
 	implementation 'io.github.cdimascio:dotenv-java:3.2.0'

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/controller/CharacterController.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/controller/CharacterController.java
@@ -1,6 +1,7 @@
 package com.github.hojoungjang.tekken_combo_maker.character.controller;
 
 import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterResponse;
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.combo.controller.IComboService;
 import com.github.hojoungjang.tekken_combo_maker.combo.dto.ComboCreateAllRequest;
 import com.github.hojoungjang.tekken_combo_maker.combo.dto.ComboDto;
@@ -28,8 +29,8 @@ public class CharacterController implements SwaggerCharacterController {
     }
 
     @GetMapping
-    public Page<CharacterResponse> getAll(Pageable pageable) {
-        return characterService.findAll(pageable);
+    public Page<CharacterResponse> getAll(CharacterSearchRequest request, Pageable pageable) {
+        return characterService.findAll(request, pageable);
     }
 
     @GetMapping("/{id}/combos")

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/controller/ICharacterService.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/controller/ICharacterService.java
@@ -1,6 +1,7 @@
 package com.github.hojoungjang.tekken_combo_maker.character.controller;
 
 import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterResponse;
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,5 +9,5 @@ public interface ICharacterService {
 
     public CharacterResponse findById(Long id);
 
-    public Page<CharacterResponse> findAll(Pageable pageable);
+    public Page<CharacterResponse> findAll(CharacterSearchRequest request, Pageable pageable);
 }

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/controller/SwaggerCharacterController.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/controller/SwaggerCharacterController.java
@@ -1,6 +1,7 @@
 package com.github.hojoungjang.tekken_combo_maker.character.controller;
 
 import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterResponse;
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.combo.dto.ComboCreateAllRequest;
 import com.github.hojoungjang.tekken_combo_maker.combo.dto.ComboDto;
 import com.github.hojoungjang.tekken_combo_maker.common.dto.BaseErrorResponse;
@@ -37,7 +38,9 @@ public interface SwaggerCharacterController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "캐릭터를 성공적으로 조회")
     })
-    Page<CharacterResponse> getAll(@ParameterObject Pageable pageable);
+    Page<CharacterResponse> getAll(
+            CharacterSearchRequest request,
+            @ParameterObject Pageable pageable);
 
     @Operation(summary = "캐릭터 콤보 목록 조회", description = "캐릭터의 전체 콤보를 조회합니다.")
     @ApiResponses({

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/controller/SwaggerCharacterController.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/controller/SwaggerCharacterController.java
@@ -39,7 +39,7 @@ public interface SwaggerCharacterController {
             @ApiResponse(responseCode = "200", description = "캐릭터를 성공적으로 조회")
     })
     Page<CharacterResponse> getAll(
-            CharacterSearchRequest request,
+            @ParameterObject CharacterSearchRequest request,
             @ParameterObject Pageable pageable);
 
     @Operation(summary = "캐릭터 콤보 목록 조회", description = "캐릭터의 전체 콤보를 조회합니다.")

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/dto/CharacterSearchRequest.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/dto/CharacterSearchRequest.java
@@ -1,0 +1,15 @@
+package com.github.hojoungjang.tekken_combo_maker.character.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CharacterSearchRequest {
+
+    private final String search;
+
+    @Builder
+    public CharacterSearchRequest(String search) {
+        this.search = search;
+    }
+}

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepository.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepository.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.github.hojoungjang.tekken_combo_maker.character.model.entity.QCharacter.character;
-import static com.github.hojoungjang.tekken_combo_maker.character.repository.predicate.CharacterSearchPredicate.characterNameContains;
+import static com.github.hojoungjang.tekken_combo_maker.character.repository.predicate.CharacterSearchPredicate.nameStartsWith;
 
 @Repository
 @Transactional(readOnly = true)
@@ -31,7 +31,7 @@ public class CharacterQueryRepository implements ICharacterQueryRepository {
         List<Character> characters = jpaQueryFactory
                 .select(character)
                 .from(character)
-                .where(characterNameContains(search))
+                .where(nameStartsWith(search))
                 .offset(offset)
                 .limit(pageSize)
                 .fetch();
@@ -39,7 +39,7 @@ public class CharacterQueryRepository implements ICharacterQueryRepository {
         Long countResult = jpaQueryFactory
                 .select(character.count())
                 .from(character)
-                .where(characterNameContains(search))
+                .where(nameStartsWith(search))
                 .fetchOne();
 
         long total = 0;

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepository.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepository.java
@@ -1,26 +1,51 @@
 package com.github.hojoungjang.tekken_combo_maker.character.repository;
 
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static com.github.hojoungjang.tekken_combo_maker.character.model.entity.QCharacter.character;
+import static com.github.hojoungjang.tekken_combo_maker.character.repository.predicate.CharacterSearchPredicate.characterNameContains;
 
 @Repository
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class CharacterQueryRepository {
+public class CharacterQueryRepository implements ICharacterQueryRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public Character getCharacterById(Long id) {
-        Character c = jpaQueryFactory.query()
+    @Override
+    public Page<Character> findAll(CharacterSearchRequest request, Pageable pageable) {
+        String search = request.getSearch();
+        long offset = pageable.getOffset();
+        int pageSize = pageable.getPageSize();
+
+        List<Character> characters = jpaQueryFactory
                 .select(character)
                 .from(character)
-                .where(character.id.eq(id))
+                .where(characterNameContains(search))
+                .offset(offset)
+                .limit(pageSize)
+                .fetch();
+
+        Long countResult = jpaQueryFactory
+                .select(character.count())
+                .from(character)
+                .where(characterNameContains(search))
                 .fetchOne();
-        return c;
+
+        long total = 0;
+        if (countResult != null) {
+            total = countResult;
+        }
+        return new PageImpl<>(characters, pageable, total);
     }
 }

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepository.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepository.java
@@ -1,0 +1,26 @@
+package com.github.hojoungjang.tekken_combo_maker.character.repository;
+
+import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.github.hojoungjang.tekken_combo_maker.character.model.entity.QCharacter.character;
+
+@Repository
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CharacterQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Character getCharacterById(Long id) {
+        Character c = jpaQueryFactory.query()
+                .select(character)
+                .from(character)
+                .where(character.id.eq(id))
+                .fetchOne();
+        return c;
+    }
+}

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterRepository.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterRepository.java
@@ -1,5 +1,6 @@
 package com.github.hojoungjang.tekken_combo_maker.character.repository;
 
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
 import com.github.hojoungjang.tekken_combo_maker.character.service.ICharacterRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class CharacterRepository implements ICharacterRepository {
     private final CharacterJpaRepository characterJpaRepository;
+    private final ICharacterQueryRepository characterQueryRepository;
 
     @Override
     public Optional<Character> findById(Long id) {
@@ -21,7 +23,7 @@ public class CharacterRepository implements ICharacterRepository {
     }
 
     @Override
-    public Page<Character> findAll(Pageable pageable) {
-        return characterJpaRepository.findAll(pageable);
+    public Page<Character> findAll(CharacterSearchRequest request, Pageable pageable) {
+        return characterQueryRepository.findAll(request, pageable);
     }
 }

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/ICharacterQueryRepository.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/ICharacterQueryRepository.java
@@ -1,0 +1,10 @@
+package com.github.hojoungjang.tekken_combo_maker.character.repository;
+
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
+import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ICharacterQueryRepository {
+    Page<Character> findAll(CharacterSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/predicate/CharacterSearchPredicate.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/predicate/CharacterSearchPredicate.java
@@ -6,11 +6,11 @@ import org.springframework.util.StringUtils;
 
 public class CharacterSearchPredicate {
 
-    public static BooleanExpression characterNameContains(String search) {
+    public static BooleanExpression nameStartsWith(String search) {
+        // TODO: might need to also match last name; May need to change full name field to last name
         if (!StringUtils.hasText(search)) {
             return null;
         }
-        return QCharacter.character.name.upper().contains(search.toUpperCase())
-                .or(QCharacter.character.fullName.upper().contains(search.toUpperCase()));
+        return QCharacter.character.name.startsWithIgnoreCase(search);
     }
 }

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/predicate/CharacterSearchPredicate.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/repository/predicate/CharacterSearchPredicate.java
@@ -1,0 +1,16 @@
+package com.github.hojoungjang.tekken_combo_maker.character.repository.predicate;
+
+import com.github.hojoungjang.tekken_combo_maker.character.model.entity.QCharacter;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.springframework.util.StringUtils;
+
+public class CharacterSearchPredicate {
+
+    public static BooleanExpression characterNameContains(String search) {
+        if (!StringUtils.hasText(search)) {
+            return null;
+        }
+        return QCharacter.character.name.upper().contains(search.toUpperCase())
+                .or(QCharacter.character.fullName.upper().contains(search.toUpperCase()));
+    }
+}

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/service/CharacterService.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/service/CharacterService.java
@@ -2,6 +2,7 @@ package com.github.hojoungjang.tekken_combo_maker.character.service;
 
 import com.github.hojoungjang.tekken_combo_maker.character.controller.ICharacterService;
 import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterResponse;
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
 import com.github.hojoungjang.tekken_combo_maker.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -30,8 +31,8 @@ public class CharacterService implements ICharacterService {
     }
 
     @Override
-    public Page<CharacterResponse> findAll(Pageable pageable) {
-        Page<Character> characters = characterRepository.findAll(pageable);
+    public Page<CharacterResponse> findAll(CharacterSearchRequest request, Pageable pageable) {
+        Page<Character> characters = characterRepository.findAll(request, pageable);
 
         return characters.map(character -> CharacterResponse.builder()
                 .id(character.getId())

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/service/ICharacterRepository.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/character/service/ICharacterRepository.java
@@ -1,15 +1,15 @@
 package com.github.hojoungjang.tekken_combo_maker.character.service;
 
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ICharacterRepository {
 
     public Optional<Character> findById(Long id);
 
-    public Page<Character> findAll(Pageable pageable);
+    public Page<Character> findAll(CharacterSearchRequest request, Pageable pageable);
 }

--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/common/config/QueryDslConfig.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/common/config/QueryDslConfig.java
@@ -1,0 +1,15 @@
+package com.github.hojoungjang.tekken_combo_maker.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,45 +25,6 @@ spring:
     console:
       enabled: true
 
-  output:
-    ansi:
-      enabled: always
-
-  data:
-    mongodb:
-      uri: mongodb+srv://${MONGODB_USER}:${MONGODB_PASSWORD}@${MONGODB_CLUSTER_URI}
-      database: ${MONGODB_DATABASE}
-
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-id: ${GOOGLE_OAUTH_CLIENT_ID}
-            client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
-            scope:
-              - email
-              - profile
-
-          discord:
-            client-id: ${DISCORD_OAUTH_CLIENT_ID}
-            client-secret: ${DISCORD_OAUTH_CLIENT_SECRET}
-            scope:
-              - email
-            client-name: Discord
-            authorization-grant-type: authorization_code
-            redirect-uri: http://localhost:8080/login/oauth2/code/discord
-            client-authentication-method: client_secret_post
-
-        provider:
-          google:
-            user-name-attribute: email
-          discord:
-            authorization-uri: https://discord.com/oauth2/authorize
-            token-uri: https://discord.com/api/oauth2/token
-            user-info-uri: https://discord.com/api/users/@me
-            user-name-attribute: email
-
 logging.level:
   org.hibernate.SQL: debug
   org.hibernate.type: trace

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -70,6 +70,9 @@ logging.level:
   org.springframework.security: DEBUG
 
 springdoc:
+  api-docs:
+    version: openapi_3_0
+
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,25 @@
+spring:
+  config:
+    import: ./env/.env.dev[.properties]
+
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+    open-in-view: false
+
+  h2:
+    console:
+      enabled: true
+
+  sql:
+    init:
+      mode: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,42 @@
 spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
+
+  output:
+    ansi:
+      enabled: always
+
+  data:
+    mongodb:
+      uri: mongodb+srv://${MONGODB_USER}:${MONGODB_PASSWORD}@${MONGODB_CLUSTER_URI}
+      database: ${MONGODB_DATABASE}
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_OAUTH_CLIENT_ID}
+            client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
+            scope:
+              - email
+              - profile
+
+          discord:
+            client-id: ${DISCORD_OAUTH_CLIENT_ID}
+            client-secret: ${DISCORD_OAUTH_CLIENT_SECRET}
+            scope:
+              - email
+            client-name: Discord
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/discord
+            client-authentication-method: client_secret_post
+
+        provider:
+          google:
+            user-name-attribute: email
+          discord:
+            authorization-uri: https://discord.com/oauth2/authorize
+            token-uri: https://discord.com/api/oauth2/token
+            user-info-uri: https://discord.com/api/users/@me
+            user-name-attribute: email

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/controller/CharacterControllerTest.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/controller/CharacterControllerTest.java
@@ -1,6 +1,7 @@
 package com.github.hojoungjang.tekken_combo_maker.character.controller;
 
 import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterResponse;
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.character.mock.FakeCharacterService;
 import com.github.hojoungjang.tekken_combo_maker.combo.dto.ComboCreateAllRequest;
 import com.github.hojoungjang.tekken_combo_maker.combo.dto.ComboCreateRequest;
@@ -14,6 +15,8 @@ import com.github.hojoungjang.tekken_combo_maker.move.model.enums.HitStatus;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -66,9 +69,10 @@ class CharacterControllerTest {
     public void 여러_캐릭터_정보를_가져올_수_있다() throws Exception {
         // given
         Pageable pageable = PageRequest.of(0, 10);
+        CharacterSearchRequest request = CharacterSearchRequest.builder().build();
 
         // when
-        Page<CharacterResponse> charactersPage = characterController.getAll(pageable);
+        Page<CharacterResponse> charactersPage = characterController.getAll(request, pageable);
 
         // then
         List<CharacterResponse> characters = charactersPage.getContent();
@@ -93,9 +97,10 @@ class CharacterControllerTest {
     public void Pagination을_사용하여_여러_캐릭터_정보를_가져올_수_있다() throws Exception {
         // given
         Pageable pageable = PageRequest.of(1, 1);
+        CharacterSearchRequest request = CharacterSearchRequest.builder().build();
 
         // when
-        Page<CharacterResponse> charactersPage = characterController.getAll(pageable);
+        Page<CharacterResponse> charactersPage = characterController.getAll(request, pageable);
 
         // then
         List<CharacterResponse> characters = charactersPage.getContent();
@@ -106,6 +111,31 @@ class CharacterControllerTest {
         Assertions.assertThat(character.getName()).isEqualTo("character 2");
         Assertions.assertThat(character.getFullName()).isEqualTo("character full 2");
         Assertions.assertThat(character.getAvatarImageName()).isEqualTo("character-2.png");
+    }
+
+    @DisplayName("검색조건에 부합하는 여러 캐릭터 정보를 가져올 수 있다")
+    @ParameterizedTest
+    @CsvSource({
+            "1, 1, character 1",
+            "CHARACTER 1, 1, character 1",
+            "cHaRactER 2, 1, character 2",
+    })
+    public void 검색조건에_부합하는_여러_캐릭터_정보를_가져올_수_있다(String searchString, int size, String characterName) throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        CharacterSearchRequest request = CharacterSearchRequest.builder()
+                .search(searchString)
+                .build();
+
+        // when
+        Page<CharacterResponse> charactersPage = characterController.getAll(request, pageable);
+
+        // then
+        List<CharacterResponse> characters = charactersPage.getContent();
+        Assertions.assertThat(characters)
+                .isNotEmpty()
+                .hasSize(size);
+        Assertions.assertThat(characters.getFirst().getName()).isEqualTo(characterName);
     }
 
     @DisplayName("캐릭터 ID 를 사용하여 해당 캐릭터의 콤보를 가져올 수 있다.")

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/controller/CharacterControllerTest.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/controller/CharacterControllerTest.java
@@ -116,11 +116,11 @@ class CharacterControllerTest {
     @DisplayName("검색조건에 부합하는 여러 캐릭터 정보를 가져올 수 있다")
     @ParameterizedTest
     @CsvSource({
-            "1, 1, character 1",
+            "ch, 3, character 1|character 2|character 3",
             "CHARACTER 1, 1, character 1",
             "cHaRactER 2, 1, character 2",
     })
-    public void 검색조건에_부합하는_여러_캐릭터_정보를_가져올_수_있다(String searchString, int size, String characterName) throws Exception {
+    public void 검색조건에_부합하는_여러_캐릭터_정보를_가져올_수_있다(String searchString, int size, String characterNames) throws Exception {
         // given
         Pageable pageable = PageRequest.of(0, 10);
         CharacterSearchRequest request = CharacterSearchRequest.builder()
@@ -135,7 +135,9 @@ class CharacterControllerTest {
         Assertions.assertThat(characters)
                 .isNotEmpty()
                 .hasSize(size);
-        Assertions.assertThat(characters.getFirst().getName()).isEqualTo(characterName);
+        Assertions.assertThat(characters)
+                .extracting(CharacterResponse::getName)
+                .containsAll(List.of(characterNames.split("\\|")));
     }
 
     @DisplayName("캐릭터 ID 를 사용하여 해당 캐릭터의 콤보를 가져올 수 있다.")

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/mock/FakeCharacterRepository.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/mock/FakeCharacterRepository.java
@@ -1,11 +1,13 @@
 package com.github.hojoungjang.tekken_combo_maker.character.mock;
 
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
 import com.github.hojoungjang.tekken_combo_maker.character.service.ICharacterRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,11 +42,17 @@ public class FakeCharacterRepository implements ICharacterRepository {
     }
 
     @Override
-    public Page<Character> findAll(Pageable pageable) {
+    public Page<Character> findAll(CharacterSearchRequest request, Pageable pageable) {
         int offset = (int) pageable.getOffset();
         int pageSize = pageable.getPageSize();
 
-        List<Character> data = new ArrayList<>(characters.subList(offset, Math.min(offset + pageSize, characters.size())));
+        String searchString = StringUtils.hasText(request.getSearch()) ? request.getSearch() : "";
+
+        List<Character> filteredCharacters = characters.stream().filter(
+                character -> character.getName().toUpperCase().contains(searchString.toUpperCase())
+                        || character.getFullName().toUpperCase().contains(searchString.toUpperCase())
+        ).toList();
+        List<Character> data = new ArrayList<>(filteredCharacters.subList(offset, Math.min(offset + pageSize, filteredCharacters.size())));
         return new PageImpl<>(data, pageable, data.size());
     }
 }

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/mock/FakeCharacterRepository.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/mock/FakeCharacterRepository.java
@@ -49,8 +49,7 @@ public class FakeCharacterRepository implements ICharacterRepository {
         String searchString = StringUtils.hasText(request.getSearch()) ? request.getSearch() : "";
 
         List<Character> filteredCharacters = characters.stream().filter(
-                character -> character.getName().toUpperCase().contains(searchString.toUpperCase())
-                        || character.getFullName().toUpperCase().contains(searchString.toUpperCase())
+                character -> character.getName().toUpperCase().startsWith(searchString.toUpperCase())
         ).toList();
         List<Character> data = new ArrayList<>(filteredCharacters.subList(offset, Math.min(offset + pageSize, filteredCharacters.size())));
         return new PageImpl<>(data, pageable, data.size());

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/mock/FakeCharacterService.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/mock/FakeCharacterService.java
@@ -2,6 +2,7 @@ package com.github.hojoungjang.tekken_combo_maker.character.mock;
 
 import com.github.hojoungjang.tekken_combo_maker.character.controller.ICharacterService;
 import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterResponse;
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
 import com.github.hojoungjang.tekken_combo_maker.character.service.ICharacterRepository;
 import com.github.hojoungjang.tekken_combo_maker.common.exception.NotFoundException;
@@ -29,8 +30,8 @@ public class FakeCharacterService implements ICharacterService {
     }
 
     @Override
-    public Page<CharacterResponse> findAll(Pageable pageable) {
-        Page<Character> characters = characterRepository.findAll(pageable);
+    public Page<CharacterResponse> findAll(CharacterSearchRequest request, Pageable pageable) {
+        Page<Character> characters = characterRepository.findAll(request, pageable);
 
         return characters.map(character -> CharacterResponse.builder()
                 .id(character.getId())

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepositoryTest.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepositoryTest.java
@@ -1,38 +1,86 @@
 package com.github.hojoungjang.tekken_combo_maker.character.repository;
 
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
-import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.Test;
+import com.github.hojoungjang.tekken_combo_maker.common.config.TestQueryDslConfig;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
 
-@SpringBootTest
-@Transactional
+@DataJpaTest
+@Import(TestQueryDslConfig.class)
 class CharacterQueryRepositoryTest {
 
     private static final Logger log = LoggerFactory.getLogger(CharacterQueryRepositoryTest.class);
-    @Autowired
-    private EntityManager em;
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        CharacterQueryRepository repo(JPAQueryFactory jpaQueryFactory) {
+            return new CharacterQueryRepository(jpaQueryFactory);
+        };
+    }
 
     @Autowired
-    private CharacterQueryRepository repo;
+    private CharacterJpaRepository jpaRepo;
 
-    @Test
-    public void getCharacterByIdTest() throws Exception {
-//        Character c = Character.builder()
-//                .name("Kazuya")
-//                .build();
-//        em.persist(c);
+    @Autowired
+    private CharacterQueryRepository queryRepo;
 
-//        Character qCharacter = repo.getCharacterById(1L);
-//        log.info("Queried character id: " + qCharacter.getId());
-//        log.info("Queried character name: " + qCharacter.getName());
+    @BeforeEach
+    void setUp() {
+        jpaRepo.deleteAll();
+        Character kazuya = Character.builder()
+                .name("Kazuya")
+                .fullName("Kazuya Mishima")
+                .description("This is for unit test")
+                .build();
+
+        Character heihachi = Character.builder()
+                .name("Heihachi")
+                .fullName("Heihachi Mishima")
+                .description("This is for unit test")
+                .build();
+        jpaRepo.save(kazuya);
+        jpaRepo.save(heihachi);
+    }
+
+    @DisplayName("검색 조건을 이용하여 캐릭터 검색을 할 수 있다.")
+    @ParameterizedTest
+    @CsvSource({
+            "kaz, 1, Kazuya",
+            "KAZUYA, 1, Kazuya",
+            "hEIHA, 1, Heihachi",
+            "h, 1, Heihachi"
+    })
+    public void findAllTest(String searchString, int size, String characterName) throws Exception {
+        // given
+        CharacterSearchRequest request = CharacterSearchRequest.builder().search(searchString).build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Character> charactersPage = queryRepo.findAll(request, pageable);
+
+        // then
+        List<Character> characters = charactersPage.getContent();
+        Assertions.assertThat(characters).isNotEmpty().hasSize(size);
+        Assertions.assertThat(characters)
+                .extracting(Character::getName).containsExactly(characterName);
     }
 
 }

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepositoryTest.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.github.hojoungjang.tekken_combo_maker.character.repository;
+
+import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class CharacterQueryRepositoryTest {
+
+    private static final Logger log = LoggerFactory.getLogger(CharacterQueryRepositoryTest.class);
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private CharacterQueryRepository repo;
+
+    @Test
+    public void getCharacterByIdTest() throws Exception {
+//        Character c = Character.builder()
+//                .name("Kazuya")
+//                .build();
+//        em.persist(c);
+
+        Character qCharacter = repo.getCharacterById(1L);
+        log.info("Queried character id: " + qCharacter.getId());
+        log.info("Queried character name: " + qCharacter.getName());
+    }
+
+}

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepositoryTest.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepositoryTest.java
@@ -30,9 +30,9 @@ class CharacterQueryRepositoryTest {
 //                .build();
 //        em.persist(c);
 
-        Character qCharacter = repo.getCharacterById(1L);
-        log.info("Queried character id: " + qCharacter.getId());
-        log.info("Queried character name: " + qCharacter.getName());
+//        Character qCharacter = repo.getCharacterById(1L);
+//        log.info("Queried character id: " + qCharacter.getId());
+//        log.info("Queried character name: " + qCharacter.getName());
     }
 
 }

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepositoryTest.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/repository/CharacterQueryRepositoryTest.java
@@ -4,13 +4,12 @@ import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRe
 import com.github.hojoungjang.tekken_combo_maker.character.model.entity.Character;
 import com.github.hojoungjang.tekken_combo_maker.common.config.TestQueryDslConfig;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -26,8 +25,6 @@ import java.util.List;
 @Import(TestQueryDslConfig.class)
 class CharacterQueryRepositoryTest {
 
-    private static final Logger log = LoggerFactory.getLogger(CharacterQueryRepositoryTest.class);
-
     @TestConfiguration
     static class TestConfig {
         @Bean
@@ -37,14 +34,13 @@ class CharacterQueryRepositoryTest {
     }
 
     @Autowired
-    private CharacterJpaRepository jpaRepo;
+    private EntityManager em;
 
     @Autowired
     private CharacterQueryRepository queryRepo;
 
     @BeforeEach
     void setUp() {
-        jpaRepo.deleteAll();
         Character kazuya = Character.builder()
                 .name("Kazuya")
                 .fullName("Kazuya Mishima")
@@ -56,8 +52,9 @@ class CharacterQueryRepositoryTest {
                 .fullName("Heihachi Mishima")
                 .description("This is for unit test")
                 .build();
-        jpaRepo.save(kazuya);
-        jpaRepo.save(heihachi);
+
+        em.persist(kazuya);
+        em.persist(heihachi);
     }
 
     @DisplayName("검색 조건을 이용하여 캐릭터 검색을 할 수 있다.")

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/service/CharacterServiceTest.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/service/CharacterServiceTest.java
@@ -1,11 +1,14 @@
 package com.github.hojoungjang.tekken_combo_maker.character.service;
 
 import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterResponse;
+import com.github.hojoungjang.tekken_combo_maker.character.dto.CharacterSearchRequest;
 import com.github.hojoungjang.tekken_combo_maker.character.mock.FakeCharacterRepository;
 import com.github.hojoungjang.tekken_combo_maker.common.exception.NotFoundException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -53,9 +56,10 @@ class CharacterServiceTest {
     public void 여러_캐릭터_엔티티를_가져올_수_있다() throws Exception {
         // given
         Pageable pageable = PageRequest.of(0, 10);
+        CharacterSearchRequest request = CharacterSearchRequest.builder().build();
 
         // when
-        Page<CharacterResponse> charactersPage = characterService.findAll(pageable);
+        Page<CharacterResponse> charactersPage = characterService.findAll(request, pageable);
 
         // then
         List<CharacterResponse> characters = charactersPage.getContent();
@@ -73,5 +77,30 @@ class CharacterServiceTest {
         Assertions.assertThat(characters)
                 .extracting(CharacterResponse::getAvatarImageName)
                 .contains("character-1.png", "character-2.png", "character-3.png");
+    }
+
+    @DisplayName("검색조건에 부합하는 캐릭터 엔티티를 가져올 수 있다")
+    @ParameterizedTest
+    @CsvSource({
+            "1, 1, character 1",
+            "CHARACTER 1, 1, character 1",
+            "cHaRactER 2, 1, character 2",
+    })
+    public void 검색조건에_부합하는_캐릭터_엔티티를_가져올_수_있다(String searchString, int size, String characterName) throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        CharacterSearchRequest request = CharacterSearchRequest.builder()
+                .search(searchString)
+                .build();
+
+        // when
+        Page<CharacterResponse> charactersPage = characterService.findAll(request, pageable);
+
+        // then
+        List<CharacterResponse> characters = charactersPage.getContent();
+        Assertions.assertThat(characters)
+                .isNotEmpty()
+                .hasSize(size);
+        Assertions.assertThat(characters.getFirst().getName()).isEqualTo(characterName);
     }
 }

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/service/CharacterServiceTest.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/character/service/CharacterServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Arrays;
 import java.util.List;
 
 class CharacterServiceTest {
@@ -82,11 +83,11 @@ class CharacterServiceTest {
     @DisplayName("검색조건에 부합하는 캐릭터 엔티티를 가져올 수 있다")
     @ParameterizedTest
     @CsvSource({
-            "1, 1, character 1",
+            "ch, 3, character 1|character 2|character 3",
             "CHARACTER 1, 1, character 1",
             "cHaRactER 2, 1, character 2",
     })
-    public void 검색조건에_부합하는_캐릭터_엔티티를_가져올_수_있다(String searchString, int size, String characterName) throws Exception {
+    public void 검색조건에_부합하는_캐릭터_엔티티를_가져올_수_있다(String searchString, int size, String characterNames) throws Exception {
         // given
         Pageable pageable = PageRequest.of(0, 10);
         CharacterSearchRequest request = CharacterSearchRequest.builder()
@@ -101,6 +102,8 @@ class CharacterServiceTest {
         Assertions.assertThat(characters)
                 .isNotEmpty()
                 .hasSize(size);
-        Assertions.assertThat(characters.getFirst().getName()).isEqualTo(characterName);
+        Assertions.assertThat(characters)
+                .extracting(CharacterResponse::getName)
+                .containsAll(List.of(characterNames.split("\\|")));
     }
 }

--- a/src/test/java/com/github/hojoungjang/tekken_combo_maker/common/config/TestQueryDslConfig.java
+++ b/src/test/java/com/github/hojoungjang/tekken_combo_maker/common/config/TestQueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.github.hojoungjang.tekken_combo_maker.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * @DataJpaTest 를 이용해 QueryDSL 코드를 테스트하기 위한 Configuration 클래스
+ */
+@TestConfiguration
+public class TestQueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}


### PR DESCRIPTION
## Summary
본 PR 에서는 QueryDSL 를 도입하여 캐릭터 검색 API 를 살짝 확장하였다.
이름 검색 문자열을 요청 파라미터로 입력받아 이름의 접두사 (prefix) 로 매칭되는 모든 캐릭터를 반환 할 수 있게 한다.
혹은 이름 검색 문자열이 주어지지 않으면 이전과 같이 모든 캐릭터를 반환한다.

이번 구현은 간단하지만 검색 조건 파라미터 수가 늘어나면 쿼리 로직 작성이 복잡해지기 때문에 QueryDSL 의 깔끔한 문법과 동적 쿼리 작성 지원이 도움이 많이 된다.

![image](https://github.com/user-attachments/assets/6e02c0b8-88f9-4fdf-9ae8-ff3b2bd0fa04)

`ICharacterQueryRepository` 인터페이스를 새로 만들고 QueryDSL 을 사용하는 `CharacterQueryRepository` 구현체를 만들었다. 기존에 있던 `CharacterJpaRepository` 에서 `ICharacterQueryRepository` 상속해서 사용할 수도 있지만 그렇게 하지 않고 `CharacterRepository` 구현체에서 `ICharacterQueryRepository` 와 `CharacterJpaRepository` 두 인터페이스에 대한 구현체를 사용하도록 하였다.

## 추가로 자료가 필요했던 부분

#### Deprecate 된 메서드
`fetchResults()` 와 `fetchCount()` 가 depreacte 되었다.
이제 직접 카운트 쿼리를 실행해 데이터의 총개수를 구해와야 하는것 같다.
`fetch()` 를 이용해 데이터를 가져오고 Q 클래스의 `count()` 를 이용해 카운틑 쿼리를 별도로 만들어 실행하였다.
[`fetchAll()`](http://querydsl.com/static/querydsl/latest/apidocs/com/querydsl/jpa/JPAQueryBase.html#fetchAll--) 도 살펴보았지만 이건 eager 로딩을 사용하는 쿼리인듯 하다.

#### QueryDSL 테스트 작성
`FakeCharacterRepository` 에 이름 매칭 조건을 알맞게 해주도록 `findAll()` 로직을 변경하여서 테스트를 진행하였는데 이때 `CharacterQueryRepository` 자체의 로직을 검증하는 테스트가 없는게 신경이 쓰여서 어떻게 자료를 찾아보다 `@DataJpaTest` 라는 것을 보고 활용을 해보았다. 이때 이 애노테이션은 JPA 와 관련된 bean 들만 만들어주기 때문에 QueryDSL 의 `JPAQueryFactory` 따로 빈으로 등록해주어야 한다 ([참고자료](https://jyami.tistory.com/124)).

추가로 이번 단위 테스트에서는 `@ParametrizedTest` 와 `@CsvSource` 를 사용해보았다.

그리고 테스트를 정상적으로 실행하기 위해 테스트 프로파일을 만들고 기존에 있던 `application.yml` 파일을 용도에 맞게 여러 프로파일로 나누었다. 

## QueryDSL 설정
필요한 의존성을 추가하면 된다 (파일 변경사항에서 자세히 확인 가능)

스프링 부트 3 에 들어오면서 기존에 필요하던 플러그인과 Q 클래스를 생성하기 위한 gradle 명령어 설정은 필요없어진것 같다.
의존성 추가 후 `build` 또는 `compileJava` 를 해주면 자동으로 Q 클래스도 생성이 된다.

## 의문점
QueryDSL 은 더 이상 관리가 되지 않는다는 이야기가 커뮤니티 사이에 돌고있고 실제 마지막 릴리즈도 오래 전인것 같다.
그렇다면 우리는 앞으로 어떤 라이브러리를 쓰게 될것인가?

## Test plan
1. 모든 테스트 코드 통과
2. 애플리케이션 실행 후 포스트맨을 통한 API 호출로 테스트