### PR TITLE
웹 프론트엔드 애플리케이션용 CORS 설정 추가

### DIFF
--- a/src/main/java/com/github/hojoungjang/tekken_combo_maker/auth/SecurityConfig.java
+++ b/src/main/java/com/github/hojoungjang/tekken_combo_maker/auth/SecurityConfig.java
@@ -3,8 +3,6 @@ package com.github.hojoungjang.tekken_combo_maker.auth;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.hojoungjang.tekken_combo_maker.auth.oauth2.CustomOAuth2UserService;
 import com.github.hojoungjang.tekken_combo_maker.member.repository.MemberRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,7 +31,6 @@ import static org.springframework.boot.autoconfigure.security.servlet.PathReques
 @Configuration
 public class SecurityConfig {
 
-    private static final Logger log = LoggerFactory.getLogger(SecurityConfig.class);
     @Value("${WEB_CLIENT_APP_URL}")
     private String webClientOrigin;
 


### PR DESCRIPTION
## Summary
CORS 설정 추가하여 스프링 애플리케이션에서 내리는 응답을 프론트엔드 애플리케이션에서 제대로 받을 수 있도록 한다.

CORS 설정을 추가하는 방법은 크게 두 가지:
1. Spring Web MVC config ([공식 문서](https://docs.spring.io/spring-framework/reference/web/webmvc-cors.html#mvc-cors-global))
2. Spring Security ([공식 문서](https://docs.spring.io/spring-security/reference/reactive/integrations/cors.html))

이때 Spring Security 를 프로젝트에서 이미 사용중일 경우, 1번 방법으로 CORS 를 정상적으로 설정해줄 수 없다. 그 이유는 spring security 에 설정된 필터들이 먼저 동작하여 요청을 처리하고 Web MVC config 설정은 컨트롤러 단에서 처리가 되기 때문이다. 따라서 세션 쿠키 정보가 없는 preflight 요청 같은 경우 spring security 인증 필터에 의해 먼저 걸러질 우려가 생긴다.

따라서 이 PR 에서는 2번 방법으로 spring security 를 이용해 `CorsWebFilter` 를 추가해주었다. 

### CORS 요약
요청하는 클라언트와 응답하는 서버의 origin 이 다른 경우를 cross origin 이라고 한다. 여기서 origin 은 프로토콜, 도메인 그리고 포트의 조합이다 (예: http://localhost:8888 에서 프로토콜은 http, 도메인은 localhost, 포트는 8888).
CORS 는 브라우저에 의해 시행이되고 기본적으로 cross origin 요청에 대한 응답 반환을 규약에 위배된다고 간주한다. 

브라우저가 응답을 정상적으로 처리하도록 하기 위해서 서버 응답에 CORS 관련 헤더 (즉 cross origin 자원 공유에 대한 조건을 명시하는 헤더) 를 추가해주어여 한다. 여기에서 기본적이고 자주 사용되는 헤더는 `Access-Control-Allow-Origin` 와 `Access-Control-Allow-Methods` 처럼 어떤 origin 에서 어떤 http method 을 허용할 것인지 명시해주어여한다.
